### PR TITLE
Remove Hostinger FTP workflow and recommend Vercel deployment

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,97 +1,39 @@
-# Guía de Despliegue para Hostinger
+# Despliegue
 
-Este documento describe cómo desplegar el sitio estático de Dr. Kombucha en Hostinger.
+Este proyecto Next.js está configurado para exportación estática (static export) y se recomienda desplegarlo en Vercel para simplicidad y seguridad.
 
-## Archivos Generados
+## Despliegue recomendado: Vercel
 
-- **`out/`**: Directorio con el sitio estático completo
-- **`drkombucha-hostinger.zip`**: Archivo ZIP del sitio listo para subir (15MB)
+1. Crear cuenta en Vercel y conectar con GitHub:
+   - Regístrate en [https://vercel.com](https://vercel.com) y autoriza acceso al repositorio `JnAlvDav/drkombucha`.
 
-## Pasos para Desplegar en Hostinger
+2. Importar el repositorio:
+   - New Project → Import Git Repository → selecciona `JnAlvDav/drkombucha`.
 
-### 1. Construir el Sitio Localmente (si es necesario)
+3. Confirmar configuración de build:
+   - Framework Preset: Next.js
+   - Build Command: `npm run build`
+   - Output Directory: `out`
 
-```bash
-npm install
-npm run build
-```
+4. Deploy:
+   - Pulsa "Deploy". Vercel realizará install → build → publish automáticamente.
+   - Revisar logs en Project → Deployments para confirmar que no hay errores.
 
-Esto genera el directorio `out/` con todos los archivos estáticos.
+## Apuntar dominio personalizado (ej. drkombucha.net)
 
-### 2. Crear el ZIP (si es necesario)
+Si tu dominio está en Hostinger, añade estos registros DNS (Hostinger → DNS Zone Editor):
 
-```bash
-zip -r drkombucha-hostinger.zip out/
-```
+- A record para `@`  → 216.198.79.1  
+- CNAME para `www` → cname.vercel-dns.com
 
-### 3. Subir a Hostinger
+Tras añadir los registros espera la propagación (minutos a 1 hora). En Vercel → Domains verás el estado de verificación y los pasos si falta algo.
 
-1. Accede al panel de control de Hostinger
-2. Ve a la sección de "Administrador de Archivos" o usa FTP
-3. Navega al directorio `public_html` (o el directorio raíz de tu dominio)
-4. Sube el archivo `drkombucha-hostinger.zip`
-5. Descomprime el archivo en el servidor
-6. Mueve el contenido de la carpeta `out/` al directorio raíz (`public_html`)
+## Nota para usuarios que prefieren Hostinger (FTP/SFTP)
 
-**Estructura final en Hostinger:**
-```
-public_html/
-├── index.html
-├── 404.html
-├── _next/
-│   └── static/
-├── images/
-│   └── hero/
-│       ├── *.png (imágenes originales)
-│       └── *.webp (imágenes optimizadas)
-└── index.txt
-```
+- Si prefieres desplegar por FTP/SFTP a Hostinger se puede reactivar un workflow automático, pero requiere:
+  - Configurar Secrets en GitHub (no incluir credenciales en el repo).
+  - Confirmar el método (FTP simple o SFTP con clave privada).
+- Contacta al equipo de desarrollo para que reactivemos y configuremos el workflow seguro en caso de necesitarlo.
 
-### 4. Configurar el Dominio
-
-Asegúrate de que tu dominio `drkombucha.net` esté apuntando correctamente a tu hosting de Hostinger.
-
-## Optimizaciones Implementadas
-
-### ✅ Imágenes WebP
-Todas las imágenes críticas ahora tienen versiones WebP que se cargan automáticamente en navegadores compatibles:
-- **logotipo-nuevo1.webp** - Logo (94% más ligero)
-- **hero.webp** - Imagen principal (92% más ligero)  
-- **scientist.webp** - Dr. Kombucha (97% más ligero)
-- **natural.webp** - Sabor natural (97% más ligero)
-- **granada.webp** - Sabor granada (93% más ligero)
-- **mango.webp** - Sabor mango (94% más ligero)
-
-Las imágenes PNG originales se mantienen como fallback para navegadores antiguos.
-
-### ✅ Metadatos Actualizados
-- URL de OpenGraph: `https://drkombucha.net`
-- Mejora el SEO y compartir en redes sociales
-
-### ✅ Configuración de Tailwind
-- Añadido el directorio `app/` al escaneo de clases CSS
-
-## Mantenimiento
-
-### Actualizar el Sitio
-
-1. Hacer cambios en el código fuente
-2. Ejecutar `npm run build`
-3. Crear nuevo ZIP: `zip -r drkombucha-hostinger.zip out/`
-4. Subir y reemplazar archivos en Hostinger
-
-### Verificar el Sitio
-
-Después del despliegue, verifica:
-- ✅ Las imágenes se cargan correctamente
-- ✅ Los enlaces de WhatsApp funcionan
-- ✅ El sitio se ve correctamente en móvil y desktop
-- ✅ Los metadatos de OpenGraph funcionan (compartir en redes sociales)
-
-## Soporte
-
-Para cualquier problema con el despliegue, contacta al equipo de soporte de Hostinger o revisa la documentación oficial.
-
----
-
-**Última actualización**: 17 de Enero 2026
+## Archivos de interés
+- `public/.htaccess` — Reglas recomendadas para servidores Apache (caching, compresión, WebP). Se deja aquí por si se realiza un deploy manual en Hostinger u otro hosting Apache.


### PR DESCRIPTION
Se elimina el workflow de despliegue automático por FTP a Hostinger porque el proyecto ya se gestiona mejor con Vercel (Next.js static export). 

Cambios:
- Actualiza `DEPLOYMENT.md` para documentar el despliegue recomendado con Vercel y pasos DNS para drkombucha.net.
- Mantiene `public/.htaccess` por si se despliega manualmente en servidores Apache en el futuro.

Nota: No existe actualmente ningún workflow `.github/workflows/deploy.yml` en el repositorio, por lo que este PR solo actualiza la documentación.

Si se prefiere volver a un despliegue FTP/SFTP, podemos reactivar el workflow y ayudar a configurar los Secrets necesarios. No se incluyen credenciales en el repositorio.